### PR TITLE
Revert to pytube to address parsing issues

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ requests = "*"
 oauth2client = "*"
 youtube-dl = "*"
 fuzzywuzzy = "*"
-pytube3 = "*"
+pytube = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e2469119c526a105bd0e7a1320f888329c94d2ebfd3df69cd7c477018b2e863c"
+            "sha256": "f1b91a45406800334ff3dff02bb8c093d7befc3ce47ec15bf6bf41ff4af78e0e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,34 +18,34 @@
     "default": {
         "ask-sdk-core": {
             "hashes": [
-                "sha256:06b3a4e3c901a2886548446ebb2fe24c5c29cf3b54b1918263b7adfda48cb873",
-                "sha256:ed3ee8bf97f0f693d05d8f51eea62ffa44a7e04254c9535d73493bfc5f3c1528"
+                "sha256:0f07095a8fa63796b3722ffc7fbeebd1ae15e458bf46985e34831f75a1a2b92d",
+                "sha256:a3aedf1083b7aa83a2dda76fc944d6801bbced7cf1a41c70a750c7097361d065"
             ],
             "index": "pypi",
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "ask-sdk-model": {
             "hashes": [
-                "sha256:42182686f9725c05a7e284bfaba089990f37016f566323d102dd6f9fdd16f4da",
-                "sha256:b25dd21fcdc1caa0e07b14fb1cec0b924fee3db78dcb6f33c0b54c7d00fcfd8a"
+                "sha256:3ba3146b484e4cee0bada3c7ffb1eea669992ad4b263959a3f723cdf9c0e10df",
+                "sha256:4eacd8af42fe21c529d9d48ec9c964a46e59137b6e2fdc0f3e9b5861e6a59ad7"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.24.0"
+            "version": "==1.29.0"
         },
         "ask-sdk-runtime": {
             "hashes": [
-                "sha256:31ae100df48a48653f2af3be35bdc0b3a8d9796635397f90618f375282c1111a",
-                "sha256:c4a80f2cc6cb2323c379f684be672ef6e6751dffab2562f0c302b7fdaf3e41b2"
+                "sha256:1fe636ac6b6818d123511667a4151e1c396ec2747a7851ad10cf33db2a128e0c",
+                "sha256:6b3f1ea45620c7db60a98252588947042dd2cca278b60abd4cc3849524187f5e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
-                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
+                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
             ],
-            "version": "==2020.6.20"
+            "version": "==2020.11.8"
         },
         "chardet": {
             "hashes": [
@@ -129,13 +129,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.1"
         },
-        "pytube3": {
+        "pytube": {
             "hashes": [
-                "sha256:98ae480a2d637572582e5c8b2e90fb7495f6d3a56daaffa7b2055113380f7d61",
-                "sha256:a02694b097c897a2afc68777e142a3d5268046960d01d4e01ac0584fda4499b1"
+                "sha256:17f1f79b9e38a9ec5546c4209bd076d1bd7dd47ed31a6eaf1bbff39e45a90aac",
+                "sha256:b62ea17e527633def0613a0e75f8a974ef0507bbe32ac13a3793add9ceb4d187"
             ],
             "index": "pypi",
-            "version": "==9.6.4"
+            "version": "==9.7.0"
         },
         "requests": {
             "hashes": [
@@ -163,27 +163,27 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
-                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
-                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "version": "==3.7.4.2"
+            "version": "==3.7.4.3"
         },
         "urllib3": {
             "hashes": [
-                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
-                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
+                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
+                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.25.10"
+            "version": "==1.25.11"
         },
         "youtube-dl": {
             "hashes": [
-                "sha256:4af90dac41dba8b2c8bdce3903177c4ecbc27d75e03a3f08070f9d9decbae829",
-                "sha256:c1bf9a20b0bc8cf6489930b96b9830156e2a7e865fc96ef628e97fa37aad8de9"
+                "sha256:b73379d6b08f03aec49a1899affe4cfd35bb92002dbdb3a3a1435a5811d4f120",
+                "sha256:bc86fae4923b9cdc34d3397ddc0bc0e9d81b4cfbd16f537f97efa5499070456f"
             ],
             "index": "pypi",
-            "version": "==2020.7.28"
+            "version": "==2020.11.1.1"
         }
     },
     "develop": {}


### PR DESCRIPTION
Reverts pytube3 to pytube to address `KeyError: 'assets'` issues. Will revisit later (pytube4, pytubeX were also candidates)